### PR TITLE
Close the bold tags, otherwise Chrome steals the next few divs

### DIFF
--- a/octoprint_printqueue/templates/printqueue_tab.jinja2
+++ b/octoprint_printqueue/templates/printqueue_tab.jinja2
@@ -1,10 +1,9 @@
-
 <div id="queue_elements" align="center">
 
 	<font color="red">	
-		<b> ALL ITEMS IN QUEUE MUST BE ABLE TO EJECT THEMSELVES FROM THE PRINT BED.<b>
-		<b> DO NOT ATTEMPT TO USE THIS QUEUE UNLESS YOU KNOW WHAT YOU ARE DOING.<b>
-		<b> YOU HAVE BEEN WARNED!! <b>
+		<b> ALL ITEMS IN QUEUE MUST BE ABLE TO EJECT THEMSELVES FROM THE PRINT BED.</b>
+		<b> DO NOT ATTEMPT TO USE THIS QUEUE UNLESS YOU KNOW WHAT YOU ARE DOING.</b>
+		<b> YOU HAVE BEEN WARNED!! </b>
 	</font>
 
 	<select id="queued_files" style="width: 95%" size="20">


### PR DESCRIPTION
and then separate plugins show up in the same tab, among other problems.
